### PR TITLE
Charm refactor

### DIFF
--- a/src/main/java/polydungeons/client/entity/EntityClientInit.java
+++ b/src/main/java/polydungeons/client/entity/EntityClientInit.java
@@ -18,8 +18,8 @@ public class EntityClientInit {
         register(PolyDungeonsEntities.BIGLIN, BiglinEntityRenderer::new);
 
         register(PolyDungeonsEntities.BLAZING_MECHANICAL, BlazingMechanicalEntityRenderer::new);
-        register(PolyDungeonsEntities.ANCHOR, FloatingItemEntityRenderer::new);
-        register(PolyDungeonsEntities.SUBSTITUTE, FloatingItemEntityRenderer::new);
+        register(PolyDungeonsEntities.ANCHOR, CharmEntityRenderer::new);
+        register(PolyDungeonsEntities.SUBSTITUTE, CharmEntityRenderer::new);
         EntityRendererRegistry.INSTANCE.register(PolyDungeonsEntities.SLINGSHOT_PROJECTILE, (dispatcher, context) -> new FlyingItemEntityRenderer<>(dispatcher, context.getItemRenderer()));
         register(PolyDungeonsEntities.SPEAR, SpearEntityRenderer::new);
         register(PolyDungeonsEntities.SPLAT, SplatEntityRenderer::new);

--- a/src/main/java/polydungeons/client/entity/renderer/CharmEntityRenderer.java
+++ b/src/main/java/polydungeons/client/entity/renderer/CharmEntityRenderer.java
@@ -1,7 +1,6 @@
 package polydungeons.client.entity.renderer;
 
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.Frustum;
 import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.EntityRenderDispatcher;
@@ -10,29 +9,28 @@ import net.minecraft.client.render.model.json.ModelTransformation;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
-import polydungeons.entity.FloatingItemEntity;
+import polydungeons.entity.charms.CharmEntity;
 
-public class FloatingItemEntityRenderer extends EntityRenderer<FloatingItemEntity> {
+public class CharmEntityRenderer extends EntityRenderer<CharmEntity> {
 
-    public FloatingItemEntityRenderer(EntityRenderDispatcher dispatcher) {
+    public CharmEntityRenderer(EntityRenderDispatcher dispatcher) {
         super(dispatcher);
     }
 
     @Override
-    public Identifier getTexture(FloatingItemEntity entity) {
+    public Identifier getTexture(CharmEntity entity) {
         return null;
     }
 
     @Override
-    protected int getBlockLight(FloatingItemEntity entity, BlockPos blockPos) {
+    protected int getBlockLight(CharmEntity entity, BlockPos blockPos) {
         return 15;
     }
 
     @Override
-    public void render(FloatingItemEntity entity, float yaw, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light) {
+    public void render(CharmEntity entity, float yaw, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light) {
         matrices.push();
         matrices.translate(0, 0, 0);
         matrices.translate(0, Math.cos(entity.age * 0.05) * 0.1, 0);

--- a/src/main/java/polydungeons/entity/IServerWorld.java
+++ b/src/main/java/polydungeons/entity/IServerWorld.java
@@ -1,0 +1,11 @@
+package polydungeons.entity;
+
+import net.minecraft.util.math.Vec3d;
+
+import java.util.Map;
+import java.util.UUID;
+
+public interface IServerWorld {
+    Map<UUID, Vec3d> polydungeons_getAnchorPositions();
+    Map<UUID, Vec3d> polydungeons_getSubstitutePositions();
+}

--- a/src/main/java/polydungeons/entity/charms/AnchorEntity.java
+++ b/src/main/java/polydungeons/entity/charms/AnchorEntity.java
@@ -1,42 +1,20 @@
 package polydungeons.entity.charms;
 
 import net.minecraft.entity.EntityType;
-import net.minecraft.entity.ItemEntity;
-import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
-import polydungeons.entity.FloatingItemEntity;
+import polydungeons.entity.IServerWorld;
 import polydungeons.item.PolyDungeonsItems;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
-public class AnchorEntity extends FloatingItemEntity {
+public class AnchorEntity extends CharmEntity {
     public static final float RADIUS = 100;
-
-    public static List<UUID> allAnchors = new ArrayList<>();
 
     public AnchorEntity(EntityType<?> type, World world) {
         super(type, world);
-        allAnchors.add(getUuid());
-    }
-
-    @Override
-    protected void initDataTracker() {
-
-    }
-
-    @Override
-    protected void readCustomDataFromTag(CompoundTag tag) {
-
-    }
-
-    @Override
-    protected void writeCustomDataToTag(CompoundTag tag) {
-
     }
 
     @Override
@@ -49,13 +27,12 @@ public class AnchorEntity extends FloatingItemEntity {
     }
 
     @Override
-    public void kill() {
-        allAnchors.remove(getUuid());
-        super.kill();
+    public ItemStack getItem() {
+        return new ItemStack(PolyDungeonsItems.ANCHOR);
     }
 
     @Override
-    public ItemStack getItem() {
-        return new ItemStack(PolyDungeonsItems.ANCHOR);
+    protected Map<UUID, Vec3d> getPositionList(IServerWorld world) {
+        return world.polydungeons_getAnchorPositions();
     }
 }

--- a/src/main/java/polydungeons/entity/charms/CharmEntity.java
+++ b/src/main/java/polydungeons/entity/charms/CharmEntity.java
@@ -1,4 +1,4 @@
-package polydungeons.entity;
+package polydungeons.entity.charms;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
@@ -6,19 +6,53 @@ import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Packet;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import polydungeons.entity.IServerWorld;
 import polydungeons.network.PolyDungeonsServerNetwork;
 
-public abstract class FloatingItemEntity extends Entity {
-    public FloatingItemEntity(EntityType<?> type, World world) {
+import java.util.Map;
+import java.util.UUID;
+
+public abstract class CharmEntity extends Entity {
+    public CharmEntity(EntityType<?> type, World world) {
         super(type, world);
     }
 
     public abstract ItemStack getItem();
 
+    protected abstract Map<UUID, Vec3d> getPositionList(IServerWorld world);
+
     public Packet<?> createSpawnPacket() {
         return PolyDungeonsServerNetwork.spawnEntity(this);
+    }
+
+    @Override
+    protected void initDataTracker() {
+    }
+
+    @Override
+    protected void readCustomDataFromTag(CompoundTag tag) {
+    }
+
+    @Override
+    protected void writeCustomDataToTag(CompoundTag tag) {
+    }
+
+    @Override
+    public void updatePosition(double x, double y, double z) {
+        super.updatePosition(x, y, z);
+        if (!world.isClient) {
+            getPositionList((IServerWorld) world).put(getUuid(), getPos());
+        }
+    }
+
+    @Override
+    public void kill() {
+        super.kill();
+        getPositionList((IServerWorld) world).remove(getUuid());
     }
 
     @Override

--- a/src/main/java/polydungeons/entity/charms/CharmHelper.java
+++ b/src/main/java/polydungeons/entity/charms/CharmHelper.java
@@ -1,0 +1,66 @@
+package polydungeons.entity.charms;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.server.world.ChunkTicketType;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public class CharmHelper {
+
+    public static <T extends Entity> T getClosestCharm(ServerWorld world, Map<UUID, Vec3d> charmPositions, Entity user, Class<T> charmType) {
+        return getClosestCharm(world, charmPositions, user, charmType, charm -> true);
+    }
+
+    public static <T extends Entity> T getClosestCharm(ServerWorld world, Map<UUID, Vec3d> charmPositions, Entity user, Class<T> charmType, Predicate<? super T> filter) {
+        return getCharm(world, charmPositions, user, charmType, Comparator.comparingDouble(user::squaredDistanceTo), filter);
+    }
+
+    public static <T extends Entity> T getArbitraryCharm(ServerWorld world, Map<UUID, Vec3d> charmPositions, Entity user, Class<T> charmType) {
+        return getArbitraryCharm(world, charmPositions, user, charmType, charm -> true);
+    }
+
+    public static <T extends Entity> T getArbitraryCharm(ServerWorld world, Map<UUID, Vec3d> charmPositions, Entity user, Class<T> charmType, Predicate<? super T> filter) {
+        return getCharm(world, charmPositions, user, charmType, null, filter);
+    }
+
+    public static <T extends Entity> T getCharm(ServerWorld world, Map<UUID, Vec3d> charmPositions, Entity user, Class<T> charmType, Comparator<Vec3d> sorter, Predicate<? super T> filter) {
+        List<UUID> charmsToRemove = new ArrayList<>(0);
+        Stream<Map.Entry<UUID, Vec3d>> charmStream = charmPositions.entrySet().stream();
+        if (sorter != null) {
+            charmStream = charmStream.sorted((a, b) -> sorter.compare(a.getValue(), b.getValue()));
+        }
+
+        T foundCharm = null;
+        for (Map.Entry<UUID, Vec3d> entry : (Iterable<Map.Entry<UUID, Vec3d>>) charmStream::iterator) {
+            Vec3d charmPos = entry.getValue();
+            ChunkPos chunkPos = new ChunkPos(MathHelper.floor(charmPos.x / 16), MathHelper.floor(charmPos.z / 16));
+            world.getChunkManager().addTicket(ChunkTicketType.field_19347, chunkPos, 1, user.getEntityId());
+            world.getChunk(chunkPos.x, chunkPos.z);
+            Entity entity = world.getEntity(entry.getKey());
+            if (charmType.isInstance(entity)) {
+                T charmEntity = charmType.cast(entity);
+                if (filter.test(charmEntity)) {
+                    foundCharm = charmEntity;
+                    break;
+                }
+            } else {
+                charmsToRemove.add(entry.getKey());
+            }
+        }
+
+        charmsToRemove.forEach(charmPositions::remove);
+
+        return foundCharm;
+    }
+
+}

--- a/src/main/java/polydungeons/entity/charms/SubstituteEntity.java
+++ b/src/main/java/polydungeons/entity/charms/SubstituteEntity.java
@@ -5,30 +5,31 @@ import net.minecraft.entity.data.DataTracker;
 import net.minecraft.entity.data.TrackedData;
 import net.minecraft.entity.data.TrackedDataHandlerRegistry;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
-import polydungeons.entity.FloatingItemEntity;
+import polydungeons.entity.IServerWorld;
 import polydungeons.entity.SlingshotProjectileEntity;
 import polydungeons.item.PolyDungeonsItems;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
-public class SubstituteEntity extends FloatingItemEntity {
+public class SubstituteEntity extends CharmEntity {
     public SubstituteEntity(EntityType<SubstituteEntity> type, World world) {
         super(type, world);
-        allSubstitutes.add(this.getUuid());
     }
-
-    public static List<UUID> allSubstitutes = new ArrayList<>();
 
     private static final TrackedData<Integer> CAPACITY = DataTracker.registerData(SlingshotProjectileEntity.class, TrackedDataHandlerRegistry.INTEGER);
 
     @Override
     public ItemStack getItem() {
         return new ItemStack(PolyDungeonsItems.SUBSTITUTE);
+    }
+
+    @Override
+    protected Map<UUID, Vec3d> getPositionList(IServerWorld world) {
+        return world.polydungeons_getSubstitutePositions();
     }
 
     public int getCapacity() {
@@ -42,12 +43,6 @@ public class SubstituteEntity extends FloatingItemEntity {
     @Override
     protected void initDataTracker() {
         dataTracker.startTracking(CAPACITY, 20);
-    }
-
-    @Override
-    public void kill() {
-        allSubstitutes.remove(this.getUuid());
-        super.kill();
     }
 
     @Override

--- a/src/main/java/polydungeons/item/ShulkerBlasterItem.java
+++ b/src/main/java/polydungeons/item/ShulkerBlasterItem.java
@@ -66,7 +66,7 @@ public class ShulkerBlasterItem extends RangedWeaponItem {
 			LivingEntity target = getTarget(player, entities);
 			((ILivingEntity) target).incrementTimesTargeted();
 			ShulkerBulletEntity entity = new ShulkerBulletEntity(world, player, target, Direction.Axis.Y);
-			entity.setPos(player.getX(), player.getY() + 1, player.getZ());
+			entity.updatePosition(player.getX(), player.getY() + 1, player.getZ());
 
 			Vec3d playerRotation = player.getRotationVector();
 

--- a/src/main/java/polydungeons/item/charms/AnchorCharmItem.java
+++ b/src/main/java/polydungeons/item/charms/AnchorCharmItem.java
@@ -9,7 +9,7 @@ public class AnchorCharmItem extends CharmItem {
     @Override
     boolean createEntity(PlayerEntity creator, Vec3d pos) {
         AnchorEntity newEntity = new AnchorEntity(PolyDungeonsEntities.ANCHOR, creator.getEntityWorld());
-        newEntity.setPos(pos.x, pos.y + 1.5, pos.z);
+        newEntity.updatePosition(pos.x, pos.y + 1.5, pos.z);
         creator.getEntityWorld().spawnEntity(newEntity);
         return true;
     }

--- a/src/main/java/polydungeons/item/charms/SubstituteCharmItem.java
+++ b/src/main/java/polydungeons/item/charms/SubstituteCharmItem.java
@@ -10,7 +10,7 @@ public class SubstituteCharmItem extends CharmItem {
     @Override
     boolean createEntity(PlayerEntity creator, Vec3d pos) {
         SubstituteEntity newEntity = new SubstituteEntity(PolyDungeonsEntities.SUBSTITUTE, creator.getEntityWorld());
-        newEntity.setPos(pos.x, pos.y + 1.5, pos.z);
+        newEntity.updatePosition(pos.x, pos.y + 1.5, pos.z);
         creator.getEntityWorld().spawnEntity(newEntity);
         return true;
     }

--- a/src/main/java/polydungeons/mixin/ServerWorldMixin.java
+++ b/src/main/java/polydungeons/mixin/ServerWorldMixin.java
@@ -1,0 +1,141 @@
+package polydungeons.mixin;
+
+import net.fabricmc.fabric.api.util.NbtType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.DoubleTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.WorldSavePath;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.profiler.Profiler;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.MutableWorldProperties;
+import net.minecraft.world.World;
+import net.minecraft.world.dimension.DimensionType;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import polydungeons.PolyDungeons;
+import polydungeons.entity.IServerWorld;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+@Mixin(ServerWorld.class)
+public abstract class ServerWorldMixin extends World implements IServerWorld {
+    @Shadow @Final private MinecraftServer server;
+
+    @Unique
+    private Map<UUID, Vec3d> anchorPositions = new HashMap<>();
+    @Unique
+    private Map<UUID, Vec3d> substitutePositions = new HashMap<>();
+
+    protected ServerWorldMixin(MutableWorldProperties mutableWorldProperties, RegistryKey<World> registryKey, RegistryKey<DimensionType> registryKey2, DimensionType dimensionType, Supplier<Profiler> profiler, boolean bl, boolean bl2, long l) {
+        super(mutableWorldProperties, registryKey, registryKey2, dimensionType, profiler, bl, bl2, l);
+    }
+
+    @Override
+    public Map<UUID, Vec3d> polydungeons_getAnchorPositions() {
+        return anchorPositions;
+    }
+
+    @Override
+    public Map<UUID, Vec3d> polydungeons_getSubstitutePositions() {
+        return substitutePositions;
+    }
+
+    @Unique
+    private void readCharms(CompoundTag rootTag) {
+        // Add more charms here
+
+        ListTag anchorPosList = rootTag.getList("Anchors", NbtType.COMPOUND);
+        readEntitiesOfInterest(anchorPosList, anchorPositions);
+
+        ListTag substitutePosList = rootTag.getList("Substitutes", NbtType.COMPOUND);
+        readEntitiesOfInterest(substitutePosList, substitutePositions);
+    }
+
+    @Unique
+    private void writeCharms(CompoundTag rootTag) {
+        // Add more charms here
+        rootTag.put("Anchors", writeEntitiesOfInterest(anchorPositions));
+        rootTag.put("Substitutes", writeEntitiesOfInterest(substitutePositions));
+    }
+
+
+
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void onLoadLevel(CallbackInfo ci) {
+        File polydungeonsDir = new File(DimensionType.getSaveDirectory(getRegistryKey(), server.getSavePath(WorldSavePath.ROOT).toFile()), PolyDungeons.MODID);
+        File anchorPositionsFile = new File(polydungeonsDir, "entities_of_interest.dat");
+        if (anchorPositionsFile.isFile()) {
+            try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(anchorPositionsFile))) {
+                CompoundTag rootTag = NbtIo.readCompressed(in);
+                readCharms(rootTag);
+            } catch (IOException e) {
+                LOGGER.error("Failed to read " + PolyDungeons.MODID +  " entities of interest", e);
+            }
+        }
+    }
+
+    @Inject(method = "saveLevel", at = @At("RETURN"))
+    private void onSaveLevel(CallbackInfo ci) {
+        File polydungeonsDir = new File(DimensionType.getSaveDirectory(getRegistryKey(), server.getSavePath(WorldSavePath.ROOT).toFile()), PolyDungeons.MODID);
+        if (!polydungeonsDir.exists() && !polydungeonsDir.mkdirs()) {
+            LOGGER.error("Failed to create " + PolyDungeons.MODID + " directory");
+            return;
+        }
+        File anchorPositionsFile = new File(polydungeonsDir, "entities_of_interest.dat");
+        try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(anchorPositionsFile))) {
+            CompoundTag rootTag = new CompoundTag();
+            writeCharms(rootTag);
+            NbtIo.writeCompressed(rootTag, out);
+        } catch (IOException e) {
+            LOGGER.error("Failed to write " + PolyDungeons.MODID + " entities of interest", e);
+        }
+    }
+
+    @Unique
+    private void readEntitiesOfInterest(ListTag interestList, Map<UUID, Vec3d> entitiesOfInterest) {
+        entitiesOfInterest.clear();
+        for (int i = 0; i < interestList.size(); i++) {
+            CompoundTag interestPos = interestList.getCompound(i);
+            UUID uuid = interestPos.getUuid("UUID");
+            ListTag posList = interestPos.getList("Pos", NbtType.DOUBLE);
+            if (posList.size() >= 3) {
+                Vec3d pos = new Vec3d(posList.getDouble(0), posList.getDouble(1), posList.getDouble(2));
+                entitiesOfInterest.put(uuid, pos);
+            }
+        }
+    }
+
+    @Unique
+    private ListTag writeEntitiesOfInterest(Map<UUID, Vec3d> entitiesOfInterest) {
+        ListTag interestList = new ListTag();
+        entitiesOfInterest.forEach((uuid, pos) -> {
+            CompoundTag interestPos = new CompoundTag();
+            interestPos.putUuid("UUID", uuid);
+            ListTag posTag = new ListTag();
+            Collections.addAll(posTag, DoubleTag.of(pos.x), DoubleTag.of(pos.y), DoubleTag.of(pos.z));
+            interestPos.put("Pos", posTag);
+            interestList.add(interestPos);
+        });
+        return interestList;
+    }
+}

--- a/src/main/resources/polydungeons.mixins.json
+++ b/src/main/resources/polydungeons.mixins.json
@@ -6,7 +6,8 @@
     "EnchantmentHelperMixin",
     "EnchantmentMixin",
     "LivingEntityMixin",
-    "MobEntityMixin"
+    "MobEntityMixin",
+    "ServerWorldMixin"
   ],
   "client": [
     "HeldItemRendererMixin",


### PR DESCRIPTION
This PR fixes a number of bugs relating to charms, including not being able to teleport after server restart, and a (much more minor this time) memory leak. The main change is how the list of entities is stored - it's now stored in the `ServerWorld` for each dimension.

The new process for implementing a charm is as follows:
- Go into `ServerWorldMixin` and add a `Map<UUID, Vec3d>` for your new charm type and add it to `readCharms` and `writeCharms` so it is saved after server restart.
- Add a getter for this map in `IServerWorld`.
- Create a charm entity class by subclassing `CharmEntity` (renamed from `FlyingItemEntity`). Override the `getItem` method which indicates which item stack will be rendered, and the `getPositionList` method which should return the appropriate position list from `IServerWorld`.
- Create a charm item class. In it, spawn the entity and call `updatePosition` to set the position and **not** `setPos` (the latter method is internal anyway and should almost never be called).
- Whenever you need to search for a charm, use one of the utility methods in `CharmHelper`, which takes the `ServerWorld`, charm position list, charm user and charm type as parameters, and optionally a predicate filter if you only want to select charms with certain properties.