### PR TITLE
Optimisations for SolidEndPortalBlockEntityRenderer

### DIFF
--- a/src/main/java/polydungeons/block/entity/DecorativeEndBlockEntity.java
+++ b/src/main/java/polydungeons/block/entity/DecorativeEndBlockEntity.java
@@ -1,7 +1,8 @@
 package polydungeons.block.entity;
 
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.BlockEntityType;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.block.Block;
 import net.minecraft.block.entity.EndPortalBlockEntity;
 import net.minecraft.util.math.Direction;
 
@@ -10,9 +11,12 @@ public class DecorativeEndBlockEntity extends EndPortalBlockEntity {
         super(PolyDungeonsBlockEntities.END_BLOCK);
     }
 
+    @Environment(EnvType.CLIENT)
     @Override
     public boolean shouldDrawSide(Direction direction) {
-        return true;
+        // Cull faces that are not visible
+        assert world != null;
+        return Block.shouldDrawSide(getCachedState(), world, getPos(), direction);
     }
 
 

--- a/src/main/java/polydungeons/block/entity/DecorativeEndBlockEntity.java
+++ b/src/main/java/polydungeons/block/entity/DecorativeEndBlockEntity.java
@@ -3,22 +3,61 @@ package polydungeons.block.entity;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.EndPortalBlockEntity;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
 
 public class DecorativeEndBlockEntity extends EndPortalBlockEntity {
+    private final Direction[] FACINGS = Direction.values();
+    private int cachedCullFaces = 0;
+    private boolean hasCachedFaces = false;
+
     public DecorativeEndBlockEntity() {
         super(PolyDungeonsBlockEntities.END_BLOCK);
+    }
+
+    @Environment(EnvType.CLIENT)
+    public void updateCullFaces() {
+        assert world != null;
+        hasCachedFaces = true;
+        int mask;
+        for (Direction dir : FACINGS) {
+            mask = 1 << dir.getId();
+            if (Block.shouldDrawSide(getCachedState(), world, getPos(), dir)) {
+                cachedCullFaces |= mask;
+            } else {
+                cachedCullFaces &= ~mask;
+            }
+        }
     }
 
     @Environment(EnvType.CLIENT)
     @Override
     public boolean shouldDrawSide(Direction direction) {
         // Cull faces that are not visible
-        assert world != null;
-        // TODO: cache these values
-        return Block.shouldDrawSide(getCachedState(), world, getPos(), direction);
+        if (!hasCachedFaces) {
+            updateCullFaces();
+        }
+        return (cachedCullFaces & (1 << direction.getId())) != 0;
     }
 
+    @Environment(EnvType.CLIENT)
+    public static void updateCullCache(BlockPos pos, World world) {
+        updateCullCacheNeighbor(pos.up(), world);
+        updateCullCacheNeighbor(pos.down(), world);
+        updateCullCacheNeighbor(pos.north(), world);
+        updateCullCacheNeighbor(pos.east(), world);
+        updateCullCacheNeighbor(pos.south(), world);
+        updateCullCacheNeighbor(pos.west(), world);
+    }
 
+    @Environment(EnvType.CLIENT)
+    public static void updateCullCacheNeighbor(BlockPos pos, World world) {
+        BlockEntity be = world.getBlockEntity(pos);
+        if (be instanceof DecorativeEndBlockEntity) {
+            ((DecorativeEndBlockEntity) be).updateCullFaces();
+        }
+    }
 }

--- a/src/main/java/polydungeons/block/entity/DecorativeEndBlockEntity.java
+++ b/src/main/java/polydungeons/block/entity/DecorativeEndBlockEntity.java
@@ -16,6 +16,7 @@ public class DecorativeEndBlockEntity extends EndPortalBlockEntity {
     public boolean shouldDrawSide(Direction direction) {
         // Cull faces that are not visible
         assert world != null;
+        // TODO: cache these values
         return Block.shouldDrawSide(getCachedState(), world, getPos(), direction);
     }
 

--- a/src/main/java/polydungeons/client/ber/SolidEndPortalBlockEntityRenderer.java
+++ b/src/main/java/polydungeons/client/ber/SolidEndPortalBlockEntityRenderer.java
@@ -1,9 +1,7 @@
 package polydungeons.client.ber;
 
-import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
 import net.minecraft.client.render.block.entity.EndPortalBlockEntityRenderer;
-import net.minecraft.client.util.math.MatrixStack;
 import polydungeons.block.entity.DecorativeEndBlockEntity;
 
 public class SolidEndPortalBlockEntityRenderer extends EndPortalBlockEntityRenderer<DecorativeEndBlockEntity> {
@@ -13,7 +11,8 @@ public class SolidEndPortalBlockEntityRenderer extends EndPortalBlockEntityRende
 
     @Override
     protected int method_3592(double d) {
-        return super.method_3592(d) + 1;
+        // Decrease the distance at which the higher layers stop being rendered
+        return super.method_3592(d * 3.0D) + 1;
     }
 
     @Override

--- a/src/main/java/polydungeons/client/ber/SolidEndPortalBlockEntityRenderer.java
+++ b/src/main/java/polydungeons/client/ber/SolidEndPortalBlockEntityRenderer.java
@@ -1,18 +1,100 @@
 package polydungeons.client.ber;
 
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
 import net.minecraft.client.render.block.entity.EndPortalBlockEntityRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Matrix4f;
 import polydungeons.block.entity.DecorativeEndBlockEntity;
 
+import java.util.Random;
+
 public class SolidEndPortalBlockEntityRenderer extends EndPortalBlockEntityRenderer<DecorativeEndBlockEntity> {
+    // Internal version of RANDOM, as EndPortalBlockEntityRenderer doesn't expose it
+    private static final Random RANDOM = new Random(31100L);
+
+    // Self contained buffers for batching draw calls per layer
+    private static final RenderLayer[] RENDER_LAYERS = new RenderLayer[16];
+    private static final BufferBuilder[] BUFFER_BUILDERS = new BufferBuilder[16];
+
+    static {
+        for (int i = 0; i < 16; i++) {
+            // Initialise each buffer and layer
+            RenderLayer layer = RenderLayer.getEndPortal(i + 1);
+            BufferBuilder builder = new BufferBuilder(layer.getExpectedBufferSize());
+            builder.begin(layer.getDrawMode(), layer.getVertexFormat());
+            RENDER_LAYERS[i] = layer;
+            BUFFER_BUILDERS[i] = builder;
+        }
+    }
+
     public SolidEndPortalBlockEntityRenderer(BlockEntityRenderDispatcher blockEntityRenderDispatcher) {
         super(blockEntityRenderDispatcher);
     }
 
+    private static boolean wasRendered = false;
+
+    /**
+     * Draws the buffer builders for each render layer to the screen.
+     * Should be called after all BER render methods have been called.
+     */
+    public static void drawBuffers() {
+        if (wasRendered) {
+            // Should only be run if render has been called at least once
+            wasRendered = false;
+            for (int i = 0; i < 16; i++) {
+                RenderLayer layer = RENDER_LAYERS[i];
+                BufferBuilder buf = BUFFER_BUILDERS[i];
+                layer.draw(buf, 0, 0, 0);
+                // Set up the buffer builder to be ready to accept vertices again
+                buf.begin(layer.getDrawMode(), layer.getVertexFormat());
+            }
+        }
+    }
+
+    public void render(DecorativeEndBlockEntity endPortalBlockEntity, float f, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, int j) {
+        wasRendered = true;
+        RANDOM.setSeed(31100L);
+        double distanceToCamera = endPortalBlockEntity.getPos().getSquaredDistance(this.dispatcher.camera.getPos(), true);
+        int layerCount = this.method_3592(distanceToCamera);
+        // Not sure on this name? Doesn't matter anyway, we override it to 1.0F
+        float depth = this.method_3594();
+        Matrix4f matrix4f = matrixStack.peek().getModel();
+
+        renderCube(endPortalBlockEntity, depth, 0.15F, matrix4f, BUFFER_BUILDERS[0]);
+        for(int l = 1; l < layerCount; ++l) {
+            renderCube(endPortalBlockEntity, depth, 2.0F / (float)(18 - l), matrix4f, BUFFER_BUILDERS[l]);
+        }
+    }
+
+    private void renderCube(DecorativeEndBlockEntity endPortalBlockEntity, float depth, float g, Matrix4f matrix4f, VertexConsumer vertexConsumer) {
+        float red = (RANDOM.nextFloat() * 0.5F + 0.1F) * g;
+        float green = (RANDOM.nextFloat() * 0.5F + 0.4F) * g;
+        float blue = (RANDOM.nextFloat() * 0.5F + 0.5F) * g;
+        renderFace(endPortalBlockEntity, matrix4f, vertexConsumer, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, red, green, blue, Direction.SOUTH);
+        renderFace(endPortalBlockEntity, matrix4f, vertexConsumer, 0.0F, 1.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, red, green, blue, Direction.NORTH);
+        renderFace(endPortalBlockEntity, matrix4f, vertexConsumer, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.0F, red, green, blue, Direction.EAST);
+        renderFace(endPortalBlockEntity, matrix4f, vertexConsumer, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 0.0F, red, green, blue, Direction.WEST);
+        renderFace(endPortalBlockEntity, matrix4f, vertexConsumer, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 1.0F, red, green, blue, Direction.DOWN);
+        renderFace(endPortalBlockEntity, matrix4f, vertexConsumer, 0.0F, 1.0F, depth, depth, 1.0F, 1.0F, 0.0F, 0.0F, red, green, blue, Direction.UP);
+    }
+
+    private void renderFace(DecorativeEndBlockEntity endPortalBlockEntity, Matrix4f matrix4f, VertexConsumer vertexConsumer, float f, float g, float h, float i, float j, float k, float l, float m, float n, float o, float p, Direction direction) {
+        if (endPortalBlockEntity.shouldDrawSide(direction)) {
+            vertexConsumer.vertex(matrix4f, f, h, j).color(n, o, p, 1.0F).next();
+            vertexConsumer.vertex(matrix4f, g, h, k).color(n, o, p, 1.0F).next();
+            vertexConsumer.vertex(matrix4f, g, i, l).color(n, o, p, 1.0F).next();
+            vertexConsumer.vertex(matrix4f, f, i, m).color(n, o, p, 1.0F).next();
+        }
+    }
+
     @Override
     protected int method_3592(double d) {
-        // Decrease the distance at which the higher layers stop being rendered
-        return super.method_3592(d * 3.0D) + 1;
+        return super.method_3592(d) + 1;
     }
 
     @Override

--- a/src/main/java/polydungeons/mixin/ClientWorldMixin.java
+++ b/src/main/java/polydungeons/mixin/ClientWorldMixin.java
@@ -1,0 +1,36 @@
+package polydungeons.mixin;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.profiler.Profiler;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.MutableWorldProperties;
+import net.minecraft.world.World;
+import net.minecraft.world.dimension.DimensionType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import polydungeons.block.entity.DecorativeEndBlockEntity;
+
+import java.util.function.Supplier;
+
+@Environment(EnvType.CLIENT)
+@Mixin(ClientWorld.class)
+public abstract class ClientWorldMixin extends World {
+    protected ClientWorldMixin(MutableWorldProperties mutableWorldProperties, RegistryKey<World> registryKey, RegistryKey<DimensionType> registryKey2, DimensionType dimensionType, Supplier<Profiler> profiler, boolean bl, boolean bl2, long l) {
+        super(mutableWorldProperties, registryKey, registryKey2, dimensionType, profiler, bl, bl2, l);
+    }
+
+    /**
+     * When a block rerender is scheduled, check its neighbors for instances of DecorativeEndPortalBlockEntity
+     * and update the cull cache if they are found.
+     */
+    @Inject(at = @At("HEAD"), method = "scheduleBlockRerenderIfNeeded(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;Lnet/minecraft/block/BlockState;)V")
+    public void onBlockRerender(BlockPos pos, BlockState old, BlockState updated, CallbackInfo ci) {
+        DecorativeEndBlockEntity.updateCullCache(pos, this);
+    }
+}

--- a/src/main/java/polydungeons/mixin/WorldRendererMixin.java
+++ b/src/main/java/polydungeons/mixin/WorldRendererMixin.java
@@ -1,0 +1,32 @@
+package polydungeons.mixin;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.render.*;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.Matrix4f;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import polydungeons.client.ber.SolidEndPortalBlockEntityRenderer;
+
+@Environment(EnvType.CLIENT)
+@Mixin(WorldRenderer.class)
+public class WorldRendererMixin {
+    /**
+     * Inject into rendering after all other BERs have been rendered (and as such all End BERs have populated the BufferBuilders)
+     * and draw the buffers to the screen.
+     * TODO: If FREX/Fabric Rendering API implements a callback for batched BER rendering, conditionally enable this
+     *     mixin and use the callback if it exists.
+     */
+    @Inject(method = "render(Lnet/minecraft/client/util/math/MatrixStack;FJZLnet/minecraft/client/render/Camera;Lnet/minecraft/client/render/GameRenderer;Lnet/minecraft/client/render/LightmapTextureManager;Lnet/minecraft/util/math/Matrix4f;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/WorldRenderer;checkEmpty(Lnet/minecraft/client/util/math/MatrixStack;)V", ordinal = 0),
+            slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/entity/BlockEntityRenderDispatcher;render(Lnet/minecraft/block/entity/BlockEntity;FLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;)V"))
+    )
+    public void afterRenderBlockEntities(MatrixStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f, CallbackInfo ci) {
+        SolidEndPortalBlockEntityRenderer.drawBuffers();
+    }
+
+}

--- a/src/main/resources/polydungeons.mixins.json
+++ b/src/main/resources/polydungeons.mixins.json
@@ -17,7 +17,8 @@
     "HeldItemRendererMixin",
     "ModelPartAccessor",
     "ModelPartCuboidAccessor",
-    "PlayerEntityRendererMixin"
+    "PlayerEntityRendererMixin",
+    "WorldRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/polydungeons.mixins.json
+++ b/src/main/resources/polydungeons.mixins.json
@@ -14,6 +14,7 @@
   ],
   "client": [
     "BuiltinModelItemRendererMixin",
+    "ClientWorldMixin",
     "HeldItemRendererMixin",
     "ModelPartAccessor",
     "ModelPartCuboidAccessor",


### PR DESCRIPTION
There seem to be several areas in the vanilla rendering of End Portals that cause severe issues when many end portal decorative blocks are placed. This PR aims to resolve several of the inefficiencies by culling invisible faces and introducing custom BufferBuilders to enable batching of render calls - as the majority of the time is spent switching between the 16 different render layers that end portal rendering uses. In order to do this, an injection into `WorldRenderer.render` is used to render these BufferBuilders to the render layers after all BERs have been run.

Do note that this PR renders the mod incompatible with Canvas, however Grondag has suggested implementing a callback in FREX which can be conditionally used instead of WorldRendererMixin.

Before: 
![image](https://user-images.githubusercontent.com/1138417/86525599-12947800-be81-11ea-8c85-32f011b6f0ae.png)
After: 
![image](https://user-images.githubusercontent.com/1138417/86525602-17592c00-be81-11ea-8d1a-4e638c37073b.png)

